### PR TITLE
Add AI/ML section with AI Detector Arena real-time benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The list is separated into Free and Paid and broken into subsections based on lo
 - [CISA Automated Indicator Sharing (AIS)](https://www.cisa.gov/topics/cyber-threats-and-advisories/information-sharing/automated-indicator-sharing-ais) - US government-led service that enables public and private organizations to exchange machine-readable threat indicators in real time.
 - [Open Threat Exchange (OTX)](https://otx.alienvault.com/api) - Community-driven threat intelligence platform that streams real-time data on malicious IPs, domains, and URL through the OTX DirectConnect API.
 
+### AI/ML
+- [AI Detector Arena](https://aidetectarena.com) - Live leaderboard and benchmark dataset for evaluating AI-generated image detectors. Real-time rankings updated as new detectors are evaluated against 2,038 images across 17 AI generators. Data accessible via HTTP API. [[DOI]](https://doi.org/10.5281/zenodo.18620634)
+
 ### Other
 - [GitHub Events](https://github.com/fastai/ghapi) - Use the GitHub API to consume public events happening on GitHub.
 - [EventSim](https://github.com/viirya/eventsim) - Tool to simulate event data


### PR DESCRIPTION
## Summary

Adding a new **AI/ML** category to the Free section with **AI Detector Arena** - a real-time benchmark and live leaderboard for evaluating AI-generated image detectors.

## Why This Fits

AI Detector Arena provides real-time data accessible via HTTP:
- **Live Leaderboard** - Rankings update in real-time as new detectors are evaluated
- **HTTP API Access** - Data accessible via standard HTTP endpoints
- **Continuous Updates** - New evaluations trigger live ranking updates

## Dataset Details

| Metric | Value |
|--------|-------|
| Total Images | 2,038 |
| AI-Generated | 1,018 |
| Real Photos | 1,020 |
| AI Generators | 17 |
| Categories | 6 |

## Links

- **Homepage:** https://aidetectarena.com
- **Benchmark Dataset:** https://aidetectarena.com/benchmark-dataset
- **DOI:** https://doi.org/10.5281/zenodo.18620634

## Changes

- Added new `AI/ML` subsection under Free category
- Added AI Detector Arena entry with description and DOI link