### PR TITLE
Add CoinPaprika and DexPaprika to Finance/Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The list is separated into Free and Paid and broken into subsections based on lo
  - [CoinCap](https://docs.coincap.io) - Provides real-time pricing and market activity for over 1,000 cryptocurrencies
  - [Polygon.io](https://polygon.io/docs/stocks/getting-started) - Provides real‑time stock market and cryptocurrency data from all US exchanges via REST and WebSocket endpoints.
  - [FinancialData.Net](https://financialdata.net/documentation) - Stock market data, financial statements, insider and institutional trading data, sustainability data, earnings releases, and much more.
+ - [CoinPaprika](https://api.coinpaprika.com) - Free cryptocurrency market data API with real-time prices, OHLCV, and tickers for 7,000+ coins. No API key required.
+ - [DexPaprika](https://api.dexpaprika.com) - Free DEX data API with real-time pool data, token prices, OHLCV, and trade history across all chains. No signup, no limits.
 
 ### Transportation
  - [Open Rail Data](https://wiki.openraildata.com/index.php/Rail_Data_FAQ) - A collection of APIs that provide data relating to the UK rail network, including reference data, train timetables, and live service updates. The live data is streamed using the STOMP protocol.


### PR DESCRIPTION
Adds two free crypto data APIs to the Finance/Crypto section:

- **CoinPaprika** — Free real-time crypto market data (7,000+ coins, OHLCV, tickers). No API key.
- **DexPaprika** — Free real-time DEX data (pools, tokens, OHLCV, trades across all chains). No signup.

Both are completely free with no authentication required.