### PR TITLE
Add PredScope Prediction Market API to Finance/Crypto section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
  - [DexPaprika](https://api.dexpaprika.com) - Free DEX data API with real-time pool data, token prices, OHLCV, and trade history across all chains. No signup, no limits.
  - [Pyth Network](https://docs.pyth.network/) - Delivers financial market data across every asset class through one API.
  - [Agent Gateway](https://agent-gateway-kappa.vercel.app/prices) - Free REST API for real-time prices of 500+ crypto tokens via Hyperliquid. No API key required. Poll `GET /prices` for live market data.
- - 
+ - [PredScope Prediction Market API](https://predscope.com/api/) - Free, real-time prediction market data. Live odds, volumes, and outcomes for 600+ events on Polymarket. JSON endpoints updated every 10 minutes. No authentication required.
 
 ### Transportation
  - [Open Rail Data](https://wiki.openraildata.com/index.php/Rail_Data_FAQ) - A collection of APIs that provide data relating to the UK rail network, including reference data, train timetables, and live service updates. The live data is streamed using the STOMP protocol.


### PR DESCRIPTION
## Summary

Adds [PredScope Prediction Market API](https://predscope.com/api/) to the **Finance/Crypto** section under Free datasets.

- Free REST API providing real-time prediction market data from Polymarket
- Live odds, volumes, and outcomes for 600+ events
- JSON endpoints updated every 10 minutes, no authentication required
- Fits the Finance/Crypto section as a financial derivatives/market data source

## Entry added

```
- [PredScope Prediction Market API](https://predscope.com/api/) - Free, real-time prediction market data. Live odds, volumes, and outcomes for 600+ events on Polymarket. JSON endpoints updated every 10 minutes. No authentication required.
```