### PR TITLE
Add Sharpe to Finance/Crypto data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
  - [CoinPaprika](https://api.coinpaprika.com) - Free cryptocurrency market data API with real-time prices, OHLCV, and tickers for 7,000+ coins. No API key required.
  - [DexPaprika](https://api.dexpaprika.com) - Free DEX data API with real-time pool data, token prices, OHLCV, and trade history across all chains. No signup, no limits.
  - [Pyth Network](https://docs.pyth.network/) - Delivers financial market data across every asset class through one API.
+ - [Sharpe](https://www.sharpe.ai/docs/free-api) - Real-time crypto market data API covering funding, derivatives, arbitrage, narratives, listings, and news.
  - [Agent Gateway](https://agent-gateway-kappa.vercel.app/prices) - Free REST API for real-time prices of 500+ crypto tokens via Hyperliquid. No API key required. Poll `GET /prices` for live market data.
  - 
 


### PR DESCRIPTION
Adds Sharpe to the Free Finance/Crypto section.

This section collects live crypto and market-data sources such as CoinCap, CoinPaprika, DexPaprika, Pyth, and exchange feeds. Sharpe fits as an HTTP API for real-time crypto market data, with public endpoints for funding rates, derivatives, arbitrage, narrative rotation, exchange listings, and news.

Disclosure: I work on Sharpe.