### PR TITLE
Add Helium MCP to Finance/Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
  - [DexPaprika](https://api.dexpaprika.com) - Free DEX data API with real-time pool data, token prices, OHLCV, and trade history across all chains. No signup, no limits.
  - [Pyth Network](https://docs.pyth.network/) - Delivers financial market data across every asset class through one API.
  - [Agent Gateway](https://agent-gateway-kappa.vercel.app/prices) - Free REST API for real-time prices of 500+ crypto tokens via Hyperliquid. No API key required. Poll `GET /prices` for live market data.
+ - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free REST + MCP API for AI-ranked options pricing (per-symbol ML fair-value, prob_ITM, Greeks) and 3.2M+ articles with 31-dimension bias scoring. JSON in/out, 50 free queries by IP, no signup. `GET /mcp_option_price/?symbol=AAPL&strike=200&expiration=2026-06-19&option_type=call`.
  - 
 
 ### Transportation


### PR DESCRIPTION
Adding Helium MCP — a free REST + MCP API combining real-time market data with structured news intelligence.

## What it provides

- **Per-symbol ML options pricing** with predicted fair value, prob_ITM, and Greeks
- **3.2M+ articles** with 31-dimension bias scoring (credibility, sensationalism, AI-authorship-probability, etc.)
- **10 REST endpoints** returning JSON, no auth needed for 50 free queries per IP
- **MCP support** for AI clients (Cursor, Claude Desktop, Windsurf) as well as plain `requests.get`

## Why it fits Finance/Crypto

It complements the existing Alpaca / Polygon / SEC EDGAR entries by adding **ML-derived options analytics** (not just raw prices) — useful for traders building real-time alpha screeners or for researchers studying option mispricing.

Example:

```python
import requests
r = requests.get(
    "https://heliumtrades.com/mcp_option_price/",
    params={"symbol": "AAPL", "strike": 200, "expiration": "2026-06-19", "option_type": "call"},
)
print(r.json())  # predicted price, prob_itm, greeks, market_price
```

Happy to add to the Information section too (3.2M articles is real-time news) if you'd prefer, or move it there instead.

Made with [Cursor](https://cursor.com)