### PR TITLE
Add Xquik real-time X source

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
 - [PurpleAir Air Quality Data](https://community.purpleair.com/t/new-api-dashboard/3981) - Developer API for accessing purple air sensor data.
 - [NewsAPI](https://newsapi.org/docs/get-started) - NewsAPI tracks headlines in 7 categories across over 50 countries, and at over a hundred top publications and blogs, in near real time. Free developer version with 24 delays available.
 - [X (Twitter)](https://developer.twitter.com/en/docs/tutorials/stream-tweets-in-real-time) - X provides a streaming interface for research or enterprise. 
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - REST and MCP access for X/Twitter search, profiles, followers, monitors, webhooks, and bulk extraction workflows.
 - [Bing News Search API](https://www.microsoft.com/en-us/bing/apis/bing-news-search-api) - Bing News Search API returns fresh news results from various sources in near real time
 - [Reuters News API](https://reutersagency.com/content-delivery-platforms/api-integrations/) - Low latency news feed from Reuters
 - [webz.io](https://webz.io/solutions/media-monitoring) - webz.io provides API with real-time information from thousnads of news sites, blogs, and discussion forums.


### PR DESCRIPTION
## Summary
- Add Xquik to the Paid Information section as a REST and MCP source for X/Twitter workflows.
- Keep the existing X streaming entry intact.

## Validation
- `git diff --check`
- changed-line dash and confidentiality scan
- Xquik repository link returned HTTP 200
- duplicate checks across memory, README, PRs, and issues
