### PR TITLE
Correct Open Weather API request rate details

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
 ### Information
 - [Wikimedia SSE](https://wikitech.wikimedia.org/wiki/Event_Platform/EventStreams) Event Stream of recent changes to the wikimedia foundation pages.
 - [Seismic Data](https://www.seismicportal.eu/realtime.html) Seismic Portal provides a websocket interface to real-time seismic events.
-- [Open Weather API](https://openweathermap.org/api) - Current weather data available free at rate of 1 request per second.
+- [Open Weather API](https://openweathermap.org/api) - Current weather data available free at rate of 1 request per ~90 seconds (only first 1000 API calls per day are free).
 - [Clima Cell](https://docs.tomorrow.io/reference/realtime-weather) - Real-time weather data in a free or paid API.
 - [NOAA Buoy Data](https://www.ndbc.noaa.gov/data/realtime2/) - Real-time buoy data from NOAA
 - [NOAA Weather Data](https://www.weather.gov/documentation/services-web-api) - Live Weather Data API from NOAA


### PR DESCRIPTION
Updated the Open Weather API request rate information based on the [current pricing](https://openweathermap.org/price#one_call).