### PR TITLE
Add EDGAR Events (real-time SEC filing events)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
  - [DexPaprika](https://api.dexpaprika.com) - Free DEX data API with real-time pool data, token prices, OHLCV, and trade history across all chains. No signup, no limits.
  - [Pyth Network](https://docs.pyth.network/) - Delivers financial market data across every asset class through one API.
  - [Agent Gateway](https://agent-gateway-kappa.vercel.app/prices) - Free REST API for real-time prices of 500+ crypto tokens via Hyperliquid. No API key required. Poll `GET /prices` for live market data.
+ - [EDGAR Events](https://edgarevents.com) - SEC EDGAR filings as typed JSON (8-K item codes, SC 13D activist stakes, S-1 and merger forms), pushed to a signed webhook within seconds of the filing. Free tier; poll or webhook.
  - 
 
 ### Transportation


### PR DESCRIPTION
Adds EDGAR Events under Free > Finance/Crypto, alongside the existing SEC EDGAR entry.

EDGAR Events watches data.sec.gov and emits filings as typed JSON: 8-K item codes with materiality flags, SC 13D activist stakes resolved to holder/target/percent-of-class, and S-1/424B and merger forms. The real-time angle that fits this list: register an HMAC-signed webhook and matching new filings are POSTed to your endpoint within seconds of hitting EDGAR, exactly-once per (webhook, event). There's also a polling REST API.

Free tier available. Site: https://edgarevents.com · Open docs (no key): https://api.edgarevents.com/docs