### PR TITLE
Add AlertX outbreak signal clusters to Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
 
 ### Health
 - [Longevity World Cup](https://longevityworldcup.com/api/data/athletes) - Live public biological-age competition dataset with athlete profiles, biomarker records, proof links, placements, and crowd-age fields. Free JSON over HTTP; no API key required.
+- [AlertX Outbreak Signal Clusters](https://alertx.enclai.net/developers) - Geolocated clusters of outbreak-shaped public health signals worldwide, rebuilt hourly, with syndrome and disease triage, confidence scores, and whether an official health authority later confirmed the event. Free JSON over HTTP; no API key required.
 
 ### IoT
 - [ThingSpeak IoT Public Channels](https://thingspeak.com/channels/public) - Crowdsourced IoT channels of users publishing various IoT sensor data in real-time. Accessible via REST API or MQTT API.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The list is separated into Free and Paid and broken into subsections based on lo
 
 ### Health
 - [Longevity World Cup](https://longevityworldcup.com/api/data/athletes) - Live public biological-age competition dataset with athlete profiles, biomarker records, proof links, placements, and crowd-age fields. Free JSON over HTTP; no API key required.
-- [AlertX Outbreak Signal Clusters](https://alertx.enclai.net/developers) - Geolocated clusters of outbreak-shaped public health signals worldwide, rebuilt hourly, with syndrome and disease triage, confidence scores, and whether an official health authority later confirmed the event. Free JSON over HTTP; no API key required.
+- [AlertX Outbreak Signal Clusters](https://alertx.enclai.net/developers) - Clusters of outbreak-shaped public health signals worldwide, rebuilt hourly, with syndrome and disease triage, confidence scores, and whether an official health authority later confirmed the event. Free JSON over HTTP, no API key required; aggregated to WHO region.
 
 ### IoT
 - [ThingSpeak IoT Public Channels](https://thingspeak.com/channels/public) - Crowdsourced IoT channels of users publishing various IoT sensor data in real-time. Accessible via REST API or MQTT API.


### PR DESCRIPTION
**What this adds**

A free, keyless JSON endpoint of geolocated disease-outbreak signal clusters, rebuilt hourly. Each cluster carries the place, first/last seen timestamps, a syndrome and disease triage with a confidence score, a risk tier, and — usefully for evaluation — whether an official health authority subsequently confirmed the event.

Docs, schemas and a worked example: https://alertx.enclai.net/developers

**Why I'm proposing it**

The Health section currently has one entry, and it covers biological-age biomarkers rather than population health signals. Real-time public-health data seems a natural fit for a real-time datasets list, and I couldn't find another free, no-key, continuously-updated outbreak feed listed here.

**Disclosure:** I work on AlertX, so this is my own project — flagging that rather than letting you find out. Happy to have it rejected on that basis, or to reword anything that reads as promotional.

**Notes on the data**

These are *unverified* open-source signals, not confirmed epidemiological data, and the payload says so in a `disclaimer` field. They are intended for expert review and research, not for clinical or policy use. The `authoritative_*` fields let a consumer check a signal against official confirmation, so the feed can be evaluated honestly rather than taken on trust.

No key and no registration. Anonymous callers get 20,000 requests/day, which is plenty for research use. Licensed CC BY-NC-SA 4.0.